### PR TITLE
Update default Edge home dir in generated config.json

### DIFF
--- a/src/iotEdgeExplorer.ts
+++ b/src/iotEdgeExplorer.ts
@@ -185,7 +185,7 @@ export class IoTEdgeExplorer extends BaseExplorer {
         "type": "docker"
     },
     "deviceConnectionString": "${connectionString}",
-    "homeDir": "${path.join(os.homedir(), "azure_iot_edge").replace(/\\/g, "\\\\")}",
+    "homeDir": "${path.join(os.platform() === "win32" ? process.env.PROGRAMDATA : "/var/lib/", "azure_iot_edge").replace(/\\/g, "\\\\")}",
     "hostName": "${fqdn().toLowerCase()}",
     "logLevel": "info",
     "schemaVersion": "1",


### PR DESCRIPTION
According to [IoT Edge Home Directory Description](https://pypi.python.org/pypi/azure-iot-edge-runtime-ctl#iot-edge-home-directory-description):

> The IoT Edge runtime needs a directory on the host machine in order to execute. This directory will contain the necessary configuration files, certificates and module specific files. Lets call this the EDGEHOMEDIR. If users do not specify a value for the EDGEHOMEDIR, these default directories will be used to setup/start/stop the IoT Edge runtime.
```
Default Host Paths:
-------------------
    Linux:   /var/lib/azure-iot-edge
    Windows: %PROGRAMDATA%\azure-iot-edge
    MacOS:   /var/lib/azure-iot-edge
```

