### PR TITLE
Reduce VSIX size by ignoring unnecessary files at runtime

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -8,8 +8,9 @@ images/**
 .gitignore
 tsconfig.json
 vsc-extension-quickstart.md
+.gitattributes
+.travis.yml
 appveyor.yml
 CONTRIBUTING.md
 package-lock.json
 tslint.json
-**/*.ts


### PR DESCRIPTION
Ignoring these fils can save the VSIX size by ~150 KB