### PR TITLE
Fix missing quotation marks in route snippet bug

### DIFF
--- a/src/jsonCompletionItemProvider.ts
+++ b/src/jsonCompletionItemProvider.ts
@@ -67,10 +67,10 @@ export class JsonCompletionItemProvider implements vscode.CompletionItemProvider
 
         const sinks: string[] = ["${4|$upstream"];
         if (moduleIds.length === 0) {
-            sinks.push(`BrokeredEndpoint(/modules/{moduleId}/inputs/{input})`);
+            sinks.push(`BrokeredEndpoint(\\"/modules/{moduleId}/inputs/{input}\\")`);
         } else {
             for (const moduleId of moduleIds) {
-                sinks.push(`BrokeredEndpoint(/modules/${moduleId}/inputs/{input})`);
+                sinks.push(`BrokeredEndpoint(\\"/modules/${moduleId}/inputs/{input}\\")`);
             }
         }
 


### PR DESCRIPTION
I was misled by the document https://docs.microsoft.com/en-us/azure/iot-edge/module-composition#specify-the-routes. There should be double quotation marks for `BrokeredEndpoint`. I have also sent PR to fix the content issue.