### PR TITLE
Update Edge home directory per iotedgectl's update

### DIFF
--- a/src/iotEdgeExplorer.ts
+++ b/src/iotEdgeExplorer.ts
@@ -239,7 +239,7 @@ export class IoTEdgeExplorer extends BaseExplorer {
         "type": "docker"
     },
     "deviceConnectionString": "${connectionString}",
-    "homeDir": "${(os.platform() === "win32" ? path.join(path.join(process.env.PROGRAMDATA, "azure-iot-edge"), "data") : path.join("/etc", "azure_iot_edge")).replace(/\\/g, "\\\\")}",
+    "homeDir": "${(os.platform() === "win32" ? path.join(process.env.PROGRAMDATA, "azure-iot-edge", "data") : path.join("/var", "lib", "azure_iot_edge")).replace(/\\/g, "\\\\")}",
     "hostName": "${fqdn().toLowerCase()}",
     "logLevel": "info",
     "schemaVersion": "1",


### PR DESCRIPTION
According to https://pypi.python.org/pypi/azure-iot-edge-runtime-ctl, updated default IoT edge host paths are:

    Linux:   /var/lib/azure-iot-edge
    Windows: %PROGRAMDATA%\azure-iot-edge\data
    MacOS:   /var/lib/azure-iot-edge