### PR TITLE
Check input is null or not in validateInput function

### DIFF
--- a/src/iotHubResourceExplorer.ts
+++ b/src/iotHubResourceExplorer.ts
@@ -273,7 +273,7 @@ export class IoTHubResourceExplorer extends BaseExplorer {
     private validateIoTHubName(name: string): string {
         const min = 3;
         const max = 50;
-        if (name.length < min || name.length > max) {
+        if (!name || name.length < min || name.length > max) {
             return `The name must be between ${min} and ${max} characters long.`;
         }
         if (name.match(/[^a-zA-Z0-9-]/)) {
@@ -318,7 +318,7 @@ export class IoTHubResourceExplorer extends BaseExplorer {
     private validateResourceGroupName(name: string): string {
         const min = 1;
         const max = 90;
-        if (name.length < min || name.length > max) {
+        if (!name || name.length < min || name.length > max) {
             return `The name must be between ${min} and ${max} characters long.`;
         }
         if (name.match(/[^a-zA-Z0-9\.\_\-\(\)]/)) {


### PR DESCRIPTION
When user press `Esc` for a input box, VS Code somehow still trigger the `validateInput` function, then the name parameter becomes `null`. Though it will not impact the Toolkit user, but will impact for DevKit extension: https://github.com/Microsoft/vscode-iot-dev-env/issues/126 . Thus we have a fix for this.