### PR TITLE
Show Module Identity for Edge device

### DIFF
--- a/package.json
+++ b/package.json
@@ -393,6 +393,10 @@
         {
           "command": "azure-iot-toolkit.getModuleTwin",
           "when": "view == iotHubDevices && viewItem == module"
+        },
+        {
+          "command": "azure-iot-toolkit.getModuleTwin",
+          "when": "view == iotHubDevices && viewItem == edge-module"
         }
       ],
       "editor/context": [

--- a/src/Model/ModuleItem.ts
+++ b/src/Model/ModuleItem.ts
@@ -8,8 +8,8 @@ export class ModuleItem extends TreeItem {
         public readonly deviceId: string,
         public readonly moduleId: string,
         public readonly runtimeStatus: string,
-        public readonly iconPath: string) {
+        public readonly iconPath: string,
+        public readonly contextValue: string) {
         super(runtimeStatus ? `${moduleId} (${runtimeStatus})` : moduleId);
-        this.contextValue = "module";
     }
 }

--- a/src/iotEdgeExplorer.ts
+++ b/src/iotEdgeExplorer.ts
@@ -122,6 +122,7 @@ export class IoTEdgeExplorer extends BaseExplorer {
             vscode.window.showTextDocument(document);
             TelemetryClient.sendEvent(Constants.IoTHubAIGetModuleTwinDoneEvent, { Result: "Success" });
         } catch (error) {
+            this._outputChannel.show();
             this.outputLine(Constants.IoTHubModuleTwinLabel, `Failed to get Module Twin: ${error}`);
             TelemetryClient.sendEvent(Constants.IoTHubAIGetModuleTwinDoneEvent, { Result: "Fail", Message: error });
         }

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -187,6 +187,7 @@ export class Utility {
                     return new ModuleItem(deviceId, module.moduleId, isConnected ? reportedTwin.modules[module.moduleId].runtimeStatus : null, iconPath);
                 }
             }
+            return new ModuleItem(deviceId, module.moduleId, null , iconPath);
         }).filter((module) => module);
     }
 

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -194,6 +194,7 @@ export class Utility {
                         isConnected && reportedTwin ? this.getModuleRuntimeStatus(module.moduleId, reportedTwin.modules) : undefined, iconPath, "edge-module");
                 }
             }
+            // If a Module does not exist in desired properties of edgeAgent, then it is a Module Identity.
             return new ModuleItem(deviceId, module.moduleId, null, iconPath, "module");
         }).filter((module) => module);
     }
@@ -280,7 +281,7 @@ export class Utility {
     }
 
     public static isValidTargetCondition(value: string): boolean {
-        return /^(deviceId|tags\..+|properties\.reported\..+).*=.+$/.test(value);
+        return /^(\*|((deviceId|tags\..+|properties\.reported\..+).*=.+))$/.test(value);
     }
 
     private static async getFilteredDeviceList(iotHubConnectionString: string, onlyEdgeDevice: boolean): Promise<DeviceItem[]> {

--- a/test/utility.test.ts
+++ b/test/utility.test.ts
@@ -53,6 +53,8 @@ suite("Utility Tests ", () => {
     });
 
     test("should be able to validate target condition", () => {
+        assert.equal(Utility.isValidTargetCondition("*"), true);
+
         assert.equal(Utility.isValidTargetCondition("tags.city='Shanghai'"), true);
 
         assert.equal(Utility.isValidTargetCondition("properties.reported.lastStatus='200'"), true);


### PR DESCRIPTION
- Show Module Identity for Edge device
- use $edgeAgent's connectionState for $edgeHub
- Allow '*' for target condition of Edge device deployment