### PR TITLE
Show better error message when listing modules in IoT Hub of basic tier

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "azure-iot-toolkit",
   "displayName": "Azure IoT Toolkit",
   "description": "Interact with Azure IoT Hub, IoT Device Management, IoT Edge Management, IoT Hub Code Generation",
-  "version": "1.3.0-rc3",
+  "version": "1.3.0-rc4",
   "publisher": "vsciot-vscode",
   "aiKey": "0caaff90-cc1c-4def-b64c-3ef33615bc9b",
   "icon": "logo.png",

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -215,10 +215,17 @@ export class Utility {
     }
 
     public static async getModules(iotHubConnectionString: string, deviceId: string): Promise<any[]> {
-        const url = `/devices/${encodeURIComponent(deviceId)}/modules?api-version=${Constants.IoTHubApiVersion}`;
-        const config = Utility.generateIoTHubAxiosRequestConfig(iotHubConnectionString, url, "get");
+        const registry: Registry = Registry.fromConnectionString(iotHubConnectionString);
 
-        return (await axios.request(config)).data;
+        return new Promise<any[]>((resolve, reject) => {
+            registry.getModulesOnDevice(deviceId, (err, modules) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(modules);
+                }
+            });
+        });
     }
 
     public static async getModuleTwin(iotHubConnectionString: string, deviceId: string, moduleId: string): Promise<string> {


### PR DESCRIPTION
Fix #150 
Switch to Node SDK, now comes with better error message:
![image](https://user-images.githubusercontent.com/1050213/44699187-a0e58900-aab5-11e8-988e-db1f4fab4550.png)
