### PR TITLE
Move explorer to Azure viewContainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,11 +67,20 @@
   ],
   "main": "./out/src/extension",
   "contributes": {
+		"viewsContainers": { 
+      "activitybar": [ 
+        { 
+          "id": "azure", 
+          "title": "Azure", 
+          "icon": "resources/azure.svg" 
+        } 
+      ] 
+    },
     "views": {
-      "explorer": [
+      "azure": [
         {
           "id": "iotHubDevices",
-          "name": "Azure IoT Hub Devices"
+          "name": "IoT Hub Devices"
         }
       ]
     },

--- a/resources/azure.svg
+++ b/resources/azure.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg height="28" width="28" version="1.1" viewBox="0 0 50 50" xmlns="http://www.w3.org/2000/svg">
+  <g>
+    <path fill="#0072C6" d="M11.423,44.326l23.623-4.156L22.894,25.748l6.328-17.346L50,44.33L11.423,44.326z M27.566,5.67L11.469,40.109v-0.034H0l12.717-21.975L27.566,5.67z" />
+  </g>
+</svg>


### PR DESCRIPTION
See Microsoft/vscode-azuretools#167

This will move the IoT Hub Devices explorer to the Azure viewContainer, along with others Azure plugins.