### PR TITLE
Fix issue copying connection strings on Linux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "azure-iot-toolkit",
-  "version": "2.1.0-rc3",
+  "version": "2.1.0-rc4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2078,6 +2078,12 @@
         "tapable": "^1.0.0"
       }
     },
+    "err-code": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
+      "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
+      "dev": true
+    },
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
@@ -2443,6 +2449,31 @@
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
       "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w==",
       "dev": true
+    },
+    "file-js": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/file-js/-/file-js-0.3.0.tgz",
+      "integrity": "sha1-+rRr94I0bJKUSZ8fDSrQfYOPJdE=",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.4.7",
+        "minimatch": "^3.0.3",
+        "proper-lockfile": "^1.2.0"
+      }
+    },
+    "filehound": {
+      "version": "1.16.5",
+      "resolved": "https://registry.npmjs.org/filehound/-/filehound-1.16.5.tgz",
+      "integrity": "sha512-pMGt+Fl/msSDMBU/3/jUtNkBvDKAeRb0eIrhyz3qB/gqFSGqWMrExCGfgTJjtch9YEKYTi1Z/N5Tpuzfj/pkBg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.1",
+        "file-js": "0.3.0",
+        "lodash": "^4.17.10",
+        "minimatch": "^3.0.4",
+        "moment": "^2.22.1",
+        "unit-compare": "^1.0.1"
+      }
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -5502,6 +5533,18 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
+    "proper-lockfile": {
+      "version": "1.2.0",
+      "resolved": "http://registry.npmjs.org/proper-lockfile/-/proper-lockfile-1.2.0.tgz",
+      "integrity": "sha1-zv9d2J0+XxD7deHo52vHWAGlnDQ=",
+      "dev": true,
+      "requires": {
+        "err-code": "^1.0.0",
+        "extend": "^3.0.0",
+        "graceful-fs": "^4.1.2",
+        "retry": "^0.10.0"
+      }
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -5857,6 +5900,12 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true
+    },
+    "retry": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
+      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=",
       "dev": true
     },
     "rhea": {
@@ -6804,6 +6853,15 @@
         "crypto-random-string": "^1.0.0"
       }
     },
+    "unit-compare": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unit-compare/-/unit-compare-1.0.1.tgz",
+      "integrity": "sha1-DHRZ8OW/U2N+qHPKPO4Y3i7so4Y=",
+      "dev": true,
+      "requires": {
+        "moment": "^2.14.1"
+      }
+    },
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -7308,6 +7366,15 @@
             "which": "^1.2.9"
           }
         }
+      }
+    },
+    "webpack-permissions-plugin": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/webpack-permissions-plugin/-/webpack-permissions-plugin-1.0.0.tgz",
+      "integrity": "sha512-EG6YIXjMHjFQpWcBiTa9UB6yKyQuhzJMUhD1Va94oNTUEYFo0wfjwJEQYMp90c7TghAltdC3pIT8wUSum7Yzkg==",
+      "dev": true,
+      "requires": {
+        "filehound": "^1.16.2"
       }
     },
     "webpack-sources": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "azure-iot-toolkit",
   "displayName": "Azure IoT Hub Toolkit",
   "description": "Interact with Azure IoT Hub, IoT Device Management, IoT Edge Management, IoT Hub Device Simulation, IoT Hub Code Generation",
-  "version": "2.1.0-rc3",
+  "version": "2.1.0-rc4",
   "publisher": "vsciot-vscode",
   "aiKey": "0caaff90-cc1c-4def-b64c-3ef33615bc9b",
   "icon": "logo.png",
@@ -631,7 +631,8 @@
     "typescript": "^2.2.1",
     "vscode": "^1.1.22",
     "webpack": "^4.27.1",
-    "webpack-cli": "^3.1.2"
+    "webpack-cli": "^3.1.2",
+    "webpack-permissions-plugin": "^1.0.0"
   },
   "dependencies": {
     "@azure/event-hubs": "^1.0.8",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@
 
 const copyWebpackPlugin = require('copy-webpack-plugin');
 const failOnErrorsPlugin = require('fail-on-errors-webpack-plugin');
+const permissionsPlugin = require('webpack-permissions-plugin');
 const terserWebpackPlugin = require('terser-webpack-plugin');
 const path = require('path');
 const webpack = require('webpack');
@@ -92,6 +93,14 @@ const config = {
         new failOnErrorsPlugin({
             failOnErrors: true,
             failOnWarnings: true,
+        }),
+        new permissionsPlugin({
+            buildFiles: [
+                {
+                    path: path.resolve(__dirname, 'dist', 'fallbacks', 'linux', 'xsel'),    // chmod +x dist/fallbacks/linux/xsel
+                    fileMode: '775'
+                }
+            ]
         })
     ],
     optimization: {


### PR DESCRIPTION
When copying the clipboardy binaries, the `x` permission bit is not reserved. Adding it back to resolve this issue. This also requires the `vsce package` command to run on Linux server.

Long term solution is to leverage VS Code's API which requires 1.30 to manipulate clipboard when VS Code 1.30 gains majority.