### PR TITLE
update twin name of distributed tracing

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -114,7 +114,7 @@ export class Constants {
     public static EnabledLabel = "Enabled";
 
     public static DeleteLabel = "Delete";
-    public static DeleteMessage = "Are you sure you want to delete";    public static readonly DISTRIBUTED_TWIN_NAME: string = "azureiot*com^dtracing^1*0*0";
+    public static DeleteMessage = "Are you sure you want to delete";    public static readonly DISTRIBUTED_TWIN_NAME: string = "azureiot*com^dtracing^1";
     public static ConnectionStringFormat = {
         [Constants.IotHubConnectionStringKey]: "HostName=<my-hostname>;SharedAccessKeyName=<my-policy>;SharedAccessKey=<my-policy-key>",
         [Constants.DeviceConnectionStringKey]: "HostName=<my-hostname>;DeviceId=<known-device-id>;SharedAccessKey=<known-device-key>",


### PR DESCRIPTION
Per latest design spec, the twin name should be "azureiot*com^dtracing^1" instead of "azureiot*com^dtracing^1*0*0"