### PR TITLE
Update simulator related wording to send D2C

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -726,7 +726,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -1425,7 +1425,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -2302,7 +2302,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
@@ -2933,12 +2933,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2957,6 +2959,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3057,6 +3060,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3142,7 +3146,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3242,12 +3247,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -5673,7 +5680,7 @@
     },
     "stream-browserify": {
       "version": "2.0.1",
-      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
       "dev": true,
       "requires": {

--- a/resources/simulator/index.html
+++ b/resources/simulator/index.html
@@ -39,7 +39,7 @@
                         </i-col>
                     </Row>
                     <i-form ref="formItem" :model="formItem" :rules="ruleValidation">
-                        <form-item prop="deviceConnectionStrings" label="Device(s) to simulate">
+                        <form-item prop="deviceConnectionStrings" label="Device(s) to send messages from">
                             <Row>
                                 <i-col span="24">
                                     <i-select v-model="formItem.deviceConnectionStrings" multiple filterable
@@ -126,7 +126,7 @@
                         </form-item>
                         <form-item>
                             <i-button :disabled="status.isProcessing" type="primary" @click="send()">
-                                Start simulation
+                                Send
                             </i-button>
                         </form-item>
                     </i-form>
@@ -136,7 +136,7 @@
         <Modal v-model="status.isProcessing" scrollable width="380" :mask-closable="false" :closable="false">
             <p slot="header" style="text-align: left;">
                 <Icon type="ios-information-circle" size="18" ></Icon>
-                <span>A simulation is in progress...</span>
+                <span>Sending D2C messages...</span>
             </p>
             <div style="text-align: left; margin-left: 24px;">
                 <p>

--- a/resources/simulator/main.js
+++ b/resources/simulator/main.js
@@ -39,7 +39,7 @@ const dummyJsonTemplate = `{
 }
 `;
 
-const plainTextTemplate = `Hello from Azure IoT Simulator!`;
+const plainTextTemplate = `Hello from Azure IoT!`;
 
 const introductionTemplate = `This page is intended to help you quickly send D2C messages.
 You only need to specify the device, the number of times, the delivery interval, and the data template.

--- a/resources/welcome/index.html
+++ b/resources/welcome/index.html
@@ -129,9 +129,11 @@
                         <li>Right-click your device and select
                             <strong>Send D2C message to IoT Hub</strong>
                         </li>
-                        <li>Enter the message you want to send</li>
+                        <li>Enter the message count, interval and message body. Click 
+                            <strong>Send</strong>
+                        </li>
                         <li>Results will be shown in
-                            <strong>OUTPUT &gt; Azure IoT Hub Toolkit</strong> view.</li>
+                            <strong>OUTPUT &gt; Send D2C Messages</strong> view.</li>
                     </ol>
                     <img src="https://raw.githubusercontent.com/wiki/Microsoft/vscode-azure-iot-toolkit/images/sendd2c.gif" alt="send d2c" />
                     <h3 id="monitor-d2c">Monitor device-to-cloud (D2C) message</h3>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -124,11 +124,11 @@ export class Constants {
     public static StateKeySubsID = "subscriptionId";
     public static StateKeyIoTHubID = "iothubid";
     public static SimulatorOutputChannelTitle = "Send D2C Messages";
-    public static SimulatorProgressBarCancelLog = "You just canceled sending simulated messages.";
-    public static SimulatorSendingMessageProgressBarTitle = "Sending Simulated Message(s)";
-    public static SimulatorLaunchEvent = "General.Simulator.Start";
-    public static SimulatorCloseEvent = "General.Simulator.Done";
-    public static SimulatorSendEvent = "AZ.Simulator.Send";
+    public static SimulatorProgressBarCancelLog = "You just canceled sending D2C messages.";
+    public static SimulatorSendingMessageProgressBarTitle = "Sending D2C Message(s)";
+    public static SimulatorLaunchEvent = "General.D2C.V2.Start";
+    public static SimulatorCloseEvent = "General.D2C.V2.Done";
+    public static SimulatorSendEvent = "AZ.D2C.V2.Send";
     public static IoTHubAILoadInterfacesTreeStartEvent = "AZ.LoadInterfacesTree.Start";
     public static IoTHubAILoadInterfacesTreeDoneEvent = "AZ.LoadInterfacesTree.Done";
 

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -21,7 +21,7 @@ export class Simulator {
   public static getInstance(context?: vscode.ExtensionContext) {
     if (!Simulator.instance) {
       if (!context) {
-        vscode.window.showErrorMessage("Cannot create Send D2C Messages webview instance.");
+        vscode.window.showErrorMessage("Cannot initialize Send D2C Messages webview resources.");
       } else {
         Simulator.instance = new Simulator(context);
       }
@@ -155,9 +155,10 @@ export class Simulator {
       } else {
         // Exit when no connection string found or the connection string is invalid.
         if (!this.iotHubConnectionString) {
-          vscode.window.showErrorMessage("Failed to launch Send D2C Messages webview: No IoT Connection String Found.");
+          var errorMessage = "Failed to launch Send D2C Messages webview: No IoT Hub Connection String Found.";
+          vscode.window.showErrorMessage(errorMessage);
           this.telemetry(Constants.SimulatorLaunchEvent, false, {
-            error: "Failed to launch Send D2C Messages webview: No IoT Connection String Found.",
+            error: errorMessage,
           });
           return;
         }

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -210,7 +210,7 @@ export class Simulator {
       this.cancelToken = false;
     } else {
       vscode.window.showErrorMessage(
-        "A previous send D2C messages operation is in progress, please wait or cancel it.",
+        "A previous sending D2C messages operation is in progress, please wait or cancel it.",
       );
     }
   }

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -21,7 +21,7 @@ export class Simulator {
   public static getInstance(context?: vscode.ExtensionContext) {
     if (!Simulator.instance) {
       if (!context) {
-        vscode.window.showErrorMessage("Cannot initialize Send D2C Messages webview resources.");
+        vscode.window.showErrorMessage("Cannot initialize Send D2C Messages webview.");
       } else {
         Simulator.instance = new Simulator(context);
       }

--- a/src/simulator.ts
+++ b/src/simulator.ts
@@ -21,7 +21,7 @@ export class Simulator {
   public static getInstance(context?: vscode.ExtensionContext) {
     if (!Simulator.instance) {
       if (!context) {
-        vscode.window.showErrorMessage("Cannot create Simulator instance.");
+        vscode.window.showErrorMessage("Cannot create Send D2C Messages webview instance.");
       } else {
         Simulator.instance = new Simulator(context);
       }
@@ -155,9 +155,9 @@ export class Simulator {
       } else {
         // Exit when no connection string found or the connection string is invalid.
         if (!this.iotHubConnectionString) {
-          vscode.window.showErrorMessage("Failed to launch Simulator: No IoT Connection String Found.");
+          vscode.window.showErrorMessage("Failed to launch Send D2C Messages webview: No IoT Connection String Found.");
           this.telemetry(Constants.SimulatorLaunchEvent, false, {
-            error: "Failed to launch Simulator: No IoT Connection String Found.",
+            error: "Failed to launch Send D2C Messages webview: No IoT Connection String Found.",
           });
           return;
         }
@@ -165,9 +165,9 @@ export class Simulator {
           const deviceList: vscode.TreeItem[] = await Utility.getDeviceList(this.iotHubConnectionString, Constants.ExtensionContext);
           deviceList.map((item) => new DeviceNode(item as DeviceItem));
         } catch (err) {
-          vscode.window.showErrorMessage("Failed to launch Simulator: " + err.message);
+          vscode.window.showErrorMessage("Failed to launch Send D2C Messages webview: " + err.message);
           this.telemetry(Constants.SimulatorLaunchEvent, false, {
-            error: "Failed to launch Simulator: " + err.message,
+            error: "Failed to launch Send D2C Messages webview: " + err.message,
           });
           return;
         }
@@ -210,7 +210,7 @@ export class Simulator {
       this.cancelToken = false;
     } else {
       vscode.window.showErrorMessage(
-        "A previous simulation is in progress, please wait or cancel it.",
+        "A previous send D2C messages operation is in progress, please wait or cancel it.",
       );
     }
   }


### PR DESCRIPTION
1. Update simulator related wording to send D2C
2. Change urls in package-lock.json to https
3. Update send D2C message part in welcome page. The gif in welcome page is hosted in github wiki, we need to update the gif along with the new version release.