### PR TITLE
Moved IoT Hub view under Azure viewContainer

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,13 +85,11 @@
       ]
     },
     "views": {
-      "explorer": [
+      "azure": [
         {
           "id": "iotHubDevices",
           "name": "%azure-iot-toolkit.name%"
-        }
-      ],
-      "azure": [
+        },
         {
           "id": "iotDpsExplorer",
           "name": "IoT Hub Device Provisioning Service"
@@ -839,6 +837,6 @@
     "vscode-test": "^1.4.1"
   },
   "extensionDependencies": [
-    "ms-vscode.azure-account"
+    "ms-azuretools.vscode-azureresourcegroups"
   ]
 }


### PR DESCRIPTION
Hi team,

I got tired of the IoT Hub view being stuck in the Explorer view container, so here's a proposed fix that moves it under the Azure view container (closes issue #209). This required a dependency on ms-azuretools.vscode-azureresourcegroups in which that view container is defined.

Please note that I've never worked with VS Code extensions before, so I make no guarantees as to the quality of this. But it works on my machine. :-)

For consistency with the other views in the Azure view container, maybe the view should be renamed just "IoT Hub" rather than "Azure IoT Hub". Feel free to make those or any other changes that you'd like.

Best regards,

Karl